### PR TITLE
argvを出力してみる

### DIFF
--- a/yk/print_argv.ml
+++ b/yk/print_argv.ml
@@ -1,0 +1,4 @@
+(* argvの1つ目以外を出力 *)
+(List.iter print_endline) (match (Array.to_list Sys.argv) with
+  | []    -> []
+  | s::ss -> ss)


### PR DESCRIPTION
`print_argv.ml`は、

- 受け取ったargv(`Sys.argv: array string`)を`list string`に変換し、
- その1つ目より後を
- 1行に1つずつ出力する。